### PR TITLE
add iphone (ios7.1), android 5.1.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -154,6 +154,18 @@ gulp.task('travis', [process.env.GULP_TASK || '']);
             platform:    'Windows 7',
             browserName: 'internet explorer',
             version:     '9.0'
+        },
+        {
+            browserName: 'iphone',
+            platform:    'OS X 10.10',
+            version:     '7.1',
+            deviceName:  'iPhone Simulator'
+        },
+        {
+            browserName: 'android',
+            platform:    'Linux',
+            version:     '5.1',
+            deviceName:  'Android Emulator'
         }
     ];
 

--- a/test/client/fixtures/sandboxes/dom/methods.js
+++ b/test/client/fixtures/sandboxes/dom/methods.js
@@ -89,11 +89,28 @@ asyncTest('head.appendChild for script', function () {
     ok(!window.top.testField);
     head.appendChild(script);
 
-    window.setTimeout(function () {
-        ok(window.top.testField);
+    var maxIterationCount = 10;
+    var iterationCount = 0;
+    var clearCheckingInterval = function (id) {
+        window.clearInterval(id);
         $(script).remove();
         start();
+    };
+
+    var intervalId = window.setInterval(function () {
+        iterationCount++;
+
+        if (window.top.testField) {
+            ok(true);
+            clearCheckingInterval(intervalId);
+        }
+
+        if (iterationCount > maxIterationCount) {
+            ok(false);
+            clearCheckingInterval(intervalId);
+        }
     }, 500);
+
 });
 
 //(B234291)

--- a/test/client/sauce-labs-runner.js
+++ b/test/client/sauce-labs-runner.js
@@ -81,7 +81,8 @@ QUnitTestRunner.prototype._startTask = function (browsers, url) {
             build:               this.options.build,
             tags:                this.options.tags,
             name:                this.options.testName,
-            'tunnel-identifier': this.options.tunnelIdentifier
+            'tunnel-identifier': this.options.tunnelIdentifier,
+            maxDuration:         300
         }
     };
 


### PR DESCRIPTION
cc @inikulin  @churkin 

Partial fix for #19 

We founded issue for Sauce labs images with Safari version 8.0 or higher - our qunit server for testings not started.
With @AlexanderMoskovkin we created the public ticket  - https://support.saucelabs.com/customer/portal/questions/13067042-the-web-site-for-js-testing-does-not-start.



