### PR TITLE
add safari 8.0 and higher sauce labs images for client tests

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -162,6 +162,17 @@ gulp.task('travis', [process.env.GULP_TASK || '']);
             deviceName:  'iPhone Simulator'
         },
         {
+            browserName: 'safari',
+            platform:    'OS X 10.10',
+            version:     '8.0'
+        },
+        {
+            browserName: 'iphone',
+            platform:    'OS X 10.10',
+            version:     '8.1',
+            deviceName:  'iPad Simulator'
+        },
+        {
             browserName: 'android',
             platform:    'Linux',
             version:     '5.1',

--- a/test/client/data/cross-domain/get-message.html
+++ b/test/client/data/cross-domain/get-message.html
@@ -11,7 +11,7 @@
 <script type="text/javascript">
     var settings = Hammerhead.get('./settings');
     settings.set({
-            CROSS_DOMAIN_PROXY_PORT : 1335
+            CROSS_DOMAIN_PROXY_PORT : 2000
     });
 
     var UrlUtil = Hammerhead.get('./utils/url');

--- a/test/client/data/cross-domain/service-message-with-handlers.html
+++ b/test/client/data/cross-domain/service-message-with-handlers.html
@@ -10,7 +10,7 @@
 <body>
 <script type="text/javascript">
     Hammerhead.get('./settings').set({
-        CROSS_DOMAIN_PROXY_PORT : 1335
+        CROSS_DOMAIN_PROXY_PORT : 2000
     });
 
     var UrlUtil = Hammerhead.get('./utils/url');

--- a/test/client/data/cross-domain/service-message.html
+++ b/test/client/data/cross-domain/service-message.html
@@ -10,7 +10,7 @@
 <body>
 <script type="text/javascript">
     Hammerhead.get('./settings').set({
-        CROSS_DOMAIN_PROXY_PORT : 1335
+        CROSS_DOMAIN_PROXY_PORT : 2000
     });
 
     var UrlUtil = Hammerhead.get('./utils/url');

--- a/test/client/data/cross-domain/target-url.html
+++ b/test/client/data/cross-domain/target-url.html
@@ -9,7 +9,7 @@
 <script type="text/javascript">
     var Settings = Hammerhead.get('./settings');
     Settings.set({
-        CROSS_DOMAIN_PROXY_PORT : 1335
+        CROSS_DOMAIN_PROXY_PORT : 2000
     });
 
     var UrlUtil = Hammerhead.get('./utils/url');

--- a/test/client/data/cross-domain/wait-loading.html
+++ b/test/client/data/cross-domain/wait-loading.html
@@ -8,7 +8,7 @@
 <body>
 <script type="text/javascript">
     Hammerhead.get('./settings').set({
-        CROSS_DOMAIN_PROXY_PORT : 1335
+        CROSS_DOMAIN_PROXY_PORT : 2000
     });
 
     var UrlUtil = Hammerhead.get('./utils/url');

--- a/test/client/data/dom-accessor-wrappers/iframe.html
+++ b/test/client/data/dom-accessor-wrappers/iframe.html
@@ -8,7 +8,7 @@
 <body>
 <script type="text/javascript">
     Hammerhead.get('./settings').set({
-        CROSS_DOMAIN_PROXY_PORT : 1335
+        CROSS_DOMAIN_PROXY_PORT : 2000
     });
 
     var UrlUtil = Hammerhead.get('./utils/url');

--- a/test/client/data/dom-processor/iframe.html
+++ b/test/client/data/dom-processor/iframe.html
@@ -8,7 +8,7 @@
 <body>
 <script type="text/javascript">
     Hammerhead.get('./settings').set({
-        CROSS_DOMAIN_PROXY_PORT : 1335
+        CROSS_DOMAIN_PROXY_PORT : 2000
     });
 
     var UrlUtil = Hammerhead.get('./utils/url');

--- a/test/client/data/dom-sandbox/iframe-with-doc-write.html
+++ b/test/client/data/dom-sandbox/iframe-with-doc-write.html
@@ -8,7 +8,7 @@
 <body>
 <script type="text/javascript">
     Hammerhead.get('./settings').set({
-        CROSS_DOMAIN_PROXY_PORT : 1335
+        CROSS_DOMAIN_PROXY_PORT : 2000
     });
 
     var UrlUtil = Hammerhead.get('./utils/url');

--- a/test/client/data/upload/iframe.html
+++ b/test/client/data/upload/iframe.html
@@ -8,7 +8,7 @@
 <body>
 <script type="text/javascript">
     Hammerhead.get('./settings').set({
-        CROSS_DOMAIN_PROXY_PORT : 1335
+        CROSS_DOMAIN_PROXY_PORT : 2000
     });
 
     var UrlUtil = Hammerhead.get('./utils/url');

--- a/test/client/fixtures/sandboxes/dom/dom-accessor-wrappers/setters.js
+++ b/test/client/fixtures/sandboxes/dom/dom-accessor-wrappers/setters.js
@@ -144,12 +144,12 @@ test('anchor', function () {
     // Origin
     // IE has no origin property
     if ('origin' in etalonEmptyAnchor) {
-        execScript('anchor.origin="http://yandex.ru:1335"');
-        etalonAnchor.origin = 'http://yandex.ru:1335';
+        execScript('anchor.origin="http://yandex.ru:2000"');
+        etalonAnchor.origin = 'http://yandex.ru:2000';
         strictEqual(execScript('anchor.origin'), etalonAnchor.origin);
 
-        execScript('emptyAnchor.origin="http://yandex.ru:1335";'); // TODO: iOS!!!
-        etalonEmptyAnchor.origin = 'http://yandex.ru:1335';
+        execScript('emptyAnchor.origin="http://yandex.ru:2000";'); // TODO: iOS!!!
+        etalonEmptyAnchor.origin = 'http://yandex.ru:2000';
         strictEqual(execScript('emptyAnchor.origin'), etalonEmptyAnchor.origin);
     }
 

--- a/test/client/fixtures/sandboxes/dom/dom-processor.js
+++ b/test/client/fixtures/sandboxes/dom/dom-processor.js
@@ -268,10 +268,10 @@ test('autocomplete attribute', function () {
 
 test('crossdomain src', function () {
     var url                   = 'http://cross.domain.com/';
-    var proxyUrl              = UrlUtil.getProxyUrl(url, location.hostname, 1336, null, null, 'iframe');
+    var proxyUrl              = UrlUtil.getProxyUrl(url, location.hostname, 2001, null, null, 'iframe');
     var storedCrossDomainPort = Settings.get().CROSS_DOMAIN_PROXY_PORT;
 
-    Settings.get().CROSS_DOMAIN_PROXY_PORT = 1336;
+    Settings.get().CROSS_DOMAIN_PROXY_PORT = 2001;
 
     var processed = Html.processHtml('<iframe src="' + url + '"></iframe>');
 

--- a/test/client/fixtures/sandboxes/message.js
+++ b/test/client/fixtures/sandboxes/message.js
@@ -18,7 +18,7 @@ asyncTest('onmessage event', function () {
     var storedCrossDomainPort = Settings.get().CROSS_DOMAIN_PROXY_PORT;
     var count                 = 0;
 
-    Settings.get().CROSS_DOMAIN_PROXY_PORT = 1336;
+    Settings.get().CROSS_DOMAIN_PROXY_PORT = 2001;
 
     $iframe[0].src = window.getCrossDomainPageUrl('get-message.html');
     $iframe.appendTo('body');
@@ -151,7 +151,7 @@ asyncTest('crossdomain', function () {
     var storedCrossDomainPort = Settings.get().CROSS_DOMAIN_PROXY_PORT;
     var serviceMsgReceived    = false;
 
-    Settings.get().CROSS_DOMAIN_PROXY_PORT = 1336;
+    Settings.get().CROSS_DOMAIN_PROXY_PORT = 2001;
 
     var serviceMsgHandler = function () {
         serviceMsgReceived = true;
@@ -180,7 +180,7 @@ asyncTest('service message handler should not call other handlers', function () 
     var storedCrossDomainPort = Settings.get().CROSS_DOMAIN_PROXY_PORT;
     var windowHandlerExecuted = false;
 
-    Settings.get().CROSS_DOMAIN_PROXY_PORT = 1336;
+    Settings.get().CROSS_DOMAIN_PROXY_PORT = 2001;
 
     var windowMessageHandler = function () {
         windowHandlerExecuted = true;

--- a/test/client/fixtures/sandboxes/shadow-ui.js
+++ b/test/client/fixtures/sandboxes/shadow-ui.js
@@ -243,7 +243,7 @@ test('isShadowContainerCollection', function () {
 asyncTest('isShadowContainerCollection for iframe contentWindow', function () {
     var storedCrossDomainPort = Settings.get().CROSS_DOMAIN_PROXY_PORT;
 
-    Settings.get().CROSS_DOMAIN_PROXY_PORT = 1336;
+    Settings.get().CROSS_DOMAIN_PROXY_PORT = 2001;
 
     var crossDomainIframe = document.createElement('iframe');
 

--- a/test/client/fixtures/util/dom.js
+++ b/test/client/fixtures/util/dom.js
@@ -202,7 +202,7 @@ asyncTest('crossdomain src', function () {
     var iframe = document.createElement('iframe');
 
     iframe.id  = 'test8';
-    iframe.src = 'http://' + location.hostname + ':1336/hammerhead/simple_page.html';
+    iframe.src = 'http://' + location.hostname + ':2001/hammerhead/simple_page.html';
     iframe.addEventListener('load', function () {
         this[Const.DOM_SANDBOX_PROCESSED_CONTEXT] = window;
         ok(!UrlUtil.isIframeWithoutSrc(this));
@@ -274,7 +274,7 @@ asyncTest('location is changed to cross-domain', function () {
             ok(!DOM.isCrossDomainIframe(this));
             ok(!DOM.isCrossDomainIframe(this, true));
 
-            this.contentDocument.location.href = 'http://' + location.hostname + ':1336/hammerhead/simple_page.html';
+            this.contentDocument.location.href = 'http://' + location.hostname + ':2001/hammerhead/simple_page.html';
             iteration++;
         }
         else {

--- a/test/client/server.js
+++ b/test/client/server.js
@@ -9,8 +9,8 @@ var http         = require('http');
 var Promise      = require('promise');
 
 //Const
-var PORT              = 1335;
-var CROSS_DOMAIN_PORT = 1336;
+var PORT              = 2000;
+var CROSS_DOMAIN_PORT = 2001;
 
 var BASE_PATH         = __dirname;
 var FIXTURES_PATH     = Path.join(BASE_PATH, '/fixtures');

--- a/test/client/test-page-setup.js
+++ b/test/client/test-page-setup.js
@@ -2,7 +2,7 @@ window.TASK_UID_PROPERTY = '364dfb2b';
 
 (function ($) {
     window.getCrossDomainPageUrl = function (page) {
-        return location.protocol + '//' + location.hostname + ':1336/' + page;
+        return location.protocol + '//' + location.hostname + ':2001/' + page;
     };
 
     var pageErrorMessage     = null;

--- a/test/server/data/manifest/expected.manifest
+++ b/test/server/data/manifest/expected.manifest
@@ -2,11 +2,11 @@ CACHE MANIFEST
 # 7/17/2013 12:00:00 AM
 
 CACHE:
-http://127.0.0.1:1836/!1337/http://127.0.0.1:1335/favicon.ico
-http://127.0.0.1:1836/!1337/http://127.0.0.1:1335/Images/Master/Logo.png
+http://127.0.0.1:1836/!1337/http://127.0.0.1:2000/favicon.ico
+http://127.0.0.1:1836/!1337/http://127.0.0.1:2000/Images/Master/Logo.png
 
 NETWORK:
 *
 
 FALLBACK:
-http://127.0.0.1:1836/!1337/http://127.0.0.1:1335/html/ http://127.0.0.1:1836/!1337/http://127.0.0.1:1335/offline.html
+http://127.0.0.1:1836/!1337/http://127.0.0.1:2000/html/ http://127.0.0.1:1836/!1337/http://127.0.0.1:2000/offline.html

--- a/test/server/proxy-test.js
+++ b/test/server/proxy-test.js
@@ -140,12 +140,12 @@ describe('Proxy', function () {
         });
 
         app.get('/T239167/send-location', function (req, res) {
-            res.writeHead(200, { 'location': 'http://127.0.0.1:1335/\u0410\u0411' });
+            res.writeHead(200, { 'location': 'http://127.0.0.1:2000/\u0410\u0411' });
             res._send('');
             res.end();
         });
 
-        destServer = app.listen(1335);
+        destServer = app.listen(2000);
     });
 
     after(function () {
@@ -283,7 +283,7 @@ describe('Proxy', function () {
 
         it('Should handle "Cookie" and "Set-Cookie" headers', function (done) {
             var options = {
-                url:            proxy.openSession('http://127.0.0.1:1335/cookie/set-and-redirect', session),
+                url:            proxy.openSession('http://127.0.0.1:2000/cookie/set-and-redirect', session),
                 followRedirect: true
             };
 
@@ -297,7 +297,7 @@ describe('Proxy', function () {
     describe('XHR same-origin policy', function () {
         it('Should restrict requests from other domain', function (done) {
             var options = {
-                url:     proxy.openSession('http://127.0.0.1:1335/page/plain-text', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/page/plain-text', session),
                 headers: {
                     referer: proxy.openSession('http://example.com', session)
                 }
@@ -315,7 +315,7 @@ describe('Proxy', function () {
         it('Should restrict preflight requests from other domain', function (done) {
             var options = {
                 method:  'OPTIONS',
-                url:     proxy.openSession('http://127.0.0.1:1335/preflight', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/preflight', session),
                 headers: {
                     referer: proxy.openSession('http://example.com', session)
                 }
@@ -333,7 +333,7 @@ describe('Proxy', function () {
         it('Should allow preflight requests from other domain if CORS is enabled', function (done) {
             var options = {
                 method:  'OPTIONS',
-                url:     proxy.openSession('http://127.0.0.1:1335/preflight', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/preflight', session),
                 headers: {
                     referer: proxy.openSession('http://example.com', session)
                 }
@@ -350,7 +350,7 @@ describe('Proxy', function () {
 
         it('Should allow requests from other domain if CORS is enabled and allowed origin is wildcard ', function (done) {
             var options = {
-                url:     proxy.openSession('http://127.0.0.1:1335/xhr-origin/allow-any', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/xhr-origin/allow-any', session),
                 headers: {
                     referer: proxy.openSession('http://example.com', session)
                 }
@@ -367,7 +367,7 @@ describe('Proxy', function () {
 
         it('Should allow requests from other domain if CORS is enabled and origin is allowed', function (done) {
             var options = {
-                url:     proxy.openSession('http://127.0.0.1:1335/xhr-origin/allow-provided', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/xhr-origin/allow-provided', session),
                 headers: {
                     referer:          proxy.openSession('http://example.com', session),
                     'x-allow-origin': 'http://example.com'
@@ -392,7 +392,7 @@ describe('Proxy', function () {
             session.injectable.styles.push('/styles.css');
 
             var options = {
-                url:     proxy.openSession('http://127.0.0.1:1335/page', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/page', session),
                 headers: {
                     accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*!/!*;q=0.8'
                 }
@@ -408,10 +408,10 @@ describe('Proxy', function () {
 
         it('Should not process XHR page requests', function (done) {
             var options = {
-                url:     proxy.openSession('http://127.0.0.1:1335/page', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/page', session),
                 headers: {
                     accept:  'text/html,application/xhtml+xml,application/xml;q=0.9,*!/!*;q=0.8',
-                    referer: proxy.openSession('http://127.0.0.1:1335/', session)
+                    referer: proxy.openSession('http://127.0.0.1:2000/', session)
                 }
             };
 
@@ -429,7 +429,7 @@ describe('Proxy', function () {
         it('Should process scripts', function (done) {
             session.id = 1337;
 
-            request(proxy.openSession('http://127.0.0.1:1335/script', session), function (err, res, body) {
+            request(proxy.openSession('http://127.0.0.1:2000/script', session), function (err, res, body) {
                 var expected = fs.readFileSync('test/server/data/script/expected.js').toString();
 
                 compareCode(body, expected);
@@ -440,7 +440,7 @@ describe('Proxy', function () {
         it('Should process manifests', function (done) {
             session.id = 1337;
 
-            request(proxy.openSession('http://127.0.0.1:1335/manifest', session), function (err, res, body) {
+            request(proxy.openSession('http://127.0.0.1:2000/manifest', session), function (err, res, body) {
                 var expected = fs.readFileSync('test/server/data/manifest/expected.manifest').toString();
 
                 compareCode(body, expected);
@@ -452,7 +452,7 @@ describe('Proxy', function () {
             session.id = 1337;
 
             var options = {
-                url:     proxy.openSession('http://127.0.0.1:1335/stylesheet', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/stylesheet', session),
                 headers: {
                     accept: 'text/css'
                 }
@@ -476,7 +476,7 @@ describe('Proxy', function () {
                 };
             };
 
-            request(proxy.openSession('http://127.0.0.1:1335/with-auth', session), function (err, res, body) {
+            request(proxy.openSession('http://127.0.0.1:2000/with-auth', session), function (err, res, body) {
                 expect(res.statusCode).eql(200);
                 expect(body).eql('42');
                 done();
@@ -491,7 +491,7 @@ describe('Proxy', function () {
                 };
             };
 
-            request(proxy.openSession('http://127.0.0.1:1335/with-auth', session), function (err, res, body) {
+            request(proxy.openSession('http://127.0.0.1:2000/with-auth', session), function (err, res, body) {
                 expect(res.statusCode).eql(401);
                 expect(body).to.be.empty;
                 done();
@@ -502,7 +502,7 @@ describe('Proxy', function () {
     describe('Regression', function () {
         it('Should force "Origin" header for the same-domain requests (B234325)', function (done) {
             var options = {
-                url:     proxy.openSession('http://127.0.0.1:1335/B234325/reply-with-origin', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/B234325/reply-with-origin', session),
                 headers: {
                     referer: proxy.openSession('http://example.com', session)
                 }
@@ -517,7 +517,7 @@ describe('Proxy', function () {
         });
 
         it('Should not send "Cookie" header if there are no cookies for the given URL (T232505)', function (done) {
-            var url = proxy.openSession('http://127.0.0.1:1335/T232505/is-cookie-header-sent', session);
+            var url = proxy.openSession('http://127.0.0.1:2000/T232505/is-cookie-header-sent', session);
 
             request(url, function (err, res, body) {
                 expect(JSON.parse(body)).to.be.false;
@@ -532,7 +532,7 @@ describe('Proxy', function () {
 
             session.handlePageError = function (ctx, err) {
                 expect(err.code).eql(ERR.PROXY_ORIGIN_SERVER_REQUEST_TIMEOUT);
-                expect(err.destUrl).eql('http://127.0.0.1:1335/T224541/hang-forever');
+                expect(err.destUrl).eql('http://127.0.0.1:2000/T224541/hang-forever');
                 ctx.res.end();
                 DestinationRequest.TIMEOUT = savedReqTimeout;
                 done();
@@ -540,7 +540,7 @@ describe('Proxy', function () {
             };
 
             var options = {
-                url:     proxy.openSession('http://127.0.0.1:1335/T224541/hang-forever', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/T224541/hang-forever', session),
                 headers: {
                     accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*!/!*;q=0.8'
                 }
@@ -551,8 +551,8 @@ describe('Proxy', function () {
 
         // NOTE: requires fix in node.js
         it.skip('Should not encode cyrillic symbols in header (T239167, GH-nodejs/io.js#1693)', function (done) {
-            var url              = proxy.openSession('http://127.0.0.1:1335/T239167/send-location', session);
-            var expectedLocation = proxy.openSession('http://127.0.0.1:1335/\u0410\u0411', session);
+            var url              = proxy.openSession('http://127.0.0.1:2000/T239167/send-location', session);
+            var expectedLocation = proxy.openSession('http://127.0.0.1:2000/\u0410\u0411', session);
 
             request(url, function (err, res) {
                 expect(res.headers['location']).eql(expectedLocation);
@@ -562,7 +562,7 @@ describe('Proxy', function () {
 
         it('Should process empty pages (B239430)', function (done) {
             var options = {
-                url:     proxy.openSession('http://127.0.0.1:1335/B239430/empty-page', session),
+                url:     proxy.openSession('http://127.0.0.1:2000/B239430/empty-page', session),
                 headers: {
                     accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*!/!*;q=0.8'
                 }

--- a/test/server/upload-test.js
+++ b/test/server/upload-test.js
@@ -217,7 +217,7 @@ describe('Upload', function () {
 
             app.post('/ie9-file-reader-shim', upload.ie9FileReaderShim);
 
-            server = app.listen(1335);
+            server = app.listen(2000);
         });
 
         after(function () {
@@ -227,7 +227,7 @@ describe('Upload', function () {
         it('Should provide file information', function (done) {
             var options = {
                 method:  'POST',
-                url:     'http://localhost:1335/ie9-file-reader-shim?filename=plain.txt&input-name=upload',
+                url:     'http://localhost:2000/ie9-file-reader-shim?filename=plain.txt&input-name=upload',
                 body:    data['epilogue-string'],
                 headers: {
                     'Content-Type': CONTENT_TYPE


### PR DESCRIPTION
cc @inikulin @churkin 
Part of #19 

Change qunit server ports from 1335, 1336 to 2000,2001.
Safari 8.0 + allows only specified ports for localhost connecting .
For more details see - https://docs.saucelabs.com/reference/sauce-connect/#can-i-access-applications-on-localhost-