### PR TITLE
Fixed querySelector when browser is not focused

### DIFF
--- a/src/client/sandbox/base.js
+++ b/src/client/sandbox/base.js
@@ -10,6 +10,6 @@ export default class SandboxBase extends EventEmitter {
 
     attach (window, document) {
         this.window   = window;
-        this.document = document;
+        this.document = document || window.document;
     }
 }

--- a/src/client/sandbox/code-instrumentation/location/index.js
+++ b/src/client/sandbox/code-instrumentation/location/index.js
@@ -1,6 +1,6 @@
 import LocationWrapper from './wrapper';
 import SandboxBase from '../../base';
-import { isLocation } from '../../../utils/types';
+import { isLocation } from '../../../utils/dom';
 import { GET_LOCATION_METH_NAME, SET_LOCATION_METH_NAME } from '../../../../processing/js';
 
 const LOCATION_WRAPPER = 'hammerhead|location-wrapper';

--- a/src/client/sandbox/code-instrumentation/properties/index.js
+++ b/src/client/sandbox/code-instrumentation/properties/index.js
@@ -7,6 +7,7 @@ import UploadSandbox from '../../upload';
 import ShadowUI from '../../shadow-ui';
 import * as domUtils from '../../../utils/dom';
 import * as typeUtils from '../../../utils/types';
+import { isStyle } from '../../../utils/style';
 import { cleanUpHtml, processHtml } from '../../../utils/html';
 import { getAnchorProperty, setAnchorProperty } from './anchor';
 import { getAttributesProperty } from './attributes';
@@ -63,7 +64,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             activeElement: {
-                condition: el => typeUtils.isDocument(el),
+                condition: el => domUtils.isDocument(el),
 
                 get: el => {
                     if (domUtils.isShadowUIElement(el.activeElement))
@@ -93,7 +94,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             cookie: {
-                condition: doc => typeUtils.isDocument(doc),
+                condition: doc => domUtils.isDocument(doc),
                 get:       () => this.sandbox.cookie.getCookie(),
                 set:       (doc, cookie) => this.sandbox.cookie.setCookie(doc, cookie)
             },
@@ -111,7 +112,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             domain: {
-                condition: doc => typeUtils.isDocument(doc),
+                condition: doc => domUtils.isDocument(doc),
                 get:       () => storedDomain ? storedDomain : LocationAccessorsInstrumentation.getLocationWrapper(window).hostname,
                 set:       (doc, domain) => storedDomain = domain
             },
@@ -199,7 +200,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             onerror: {
-                condition: owner => typeUtils.isWindow(owner),
+                condition: owner => domUtils.isWindow(owner),
                 get:       owner => owner[ORIGINAL_WINDOW_ON_ERROR_HANDLER_KEY] || null,
 
                 set: (owner, handler) => {
@@ -244,7 +245,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             location: {
-                condition: owner => typeUtils.isDocument(owner) || typeUtils.isWindow(owner),
+                condition: owner => domUtils.isDocument(owner) || domUtils.isWindow(owner),
 
                 get: owner => {
                     var locationWrapper = LocationAccessorsInstrumentation.getLocationWrapper(owner);
@@ -252,7 +253,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
                     if (locationWrapper)
                         return locationWrapper;
 
-                    var window = typeUtils.isWindow(owner) ? owner : owner.defaultView;
+                    var window = domUtils.isWindow(owner) ? owner : owner.defaultView;
 
                     return new LocationWrapper(window);
                 },
@@ -310,7 +311,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             referrer: {
-                condition: doc => typeUtils.isDocument(doc),
+                condition: doc => domUtils.isDocument(doc),
 
                 get: doc => {
                     var proxyUrl = urlUtils.parseProxyUrl(doc.referrer);
@@ -390,7 +391,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             URL: {
-                condition: doc => typeUtils.isDocument(doc),
+                condition: doc => domUtils.isDocument(doc),
                 get:       doc => LocationAccessorsInstrumentation.getLocationWrapper(doc).href,
                 set:       () => void 0
             },
@@ -421,13 +422,13 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
 
             // Event
             onbeforeunload: {
-                condition: window => typeUtils.isWindow(window),
+                condition: window => domUtils.isWindow(window),
                 get:       () => this.sandbox.event.unload.getOnBeforeUnload(),
                 set:       (window, handler) => this.sandbox.event.unload.setOnBeforeUnload(window, handler)
             },
 
             onmessage: {
-                condition: window => typeUtils.isWindow(window),
+                condition: window => domUtils.isWindow(window),
                 get:       () => this.sandbox.message.getOnMessage(),
                 set:       (window, handler) => this.sandbox.message.setOnMessage(window, handler)
             },
@@ -445,7 +446,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
 
             // Style
             background: {
-                condition: style => typeUtils.isStyle(style),
+                condition: style => isStyle(style),
                 get:       style => cleanUpStyle(style.background, urlUtils.parseProxyUrl, urlUtils.formatUrl),
 
                 set: (style, value) => {
@@ -457,7 +458,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             backgroundImage: {
-                condition: style => typeUtils.isStyle(style),
+                condition: style => isStyle(style),
                 get:       style => cleanUpStyle(style.backgroundImage, urlUtils.parseProxyUrl, urlUtils.formatUrl),
 
                 set: (style, value) => {
@@ -469,7 +470,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             borderImage: {
-                condition: style => typeUtils.isStyle(style),
+                condition: style => isStyle(style),
                 get:       style => cleanUpStyle(style.borderImage, urlUtils.parseProxyUrl, urlUtils.formatUrl),
 
                 set: (style, value) => {
@@ -481,7 +482,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             cssText: {
-                condition: style => typeUtils.isStyle(style),
+                condition: style => isStyle(style),
                 get:       style => cleanUpStyle(style.cssText, urlUtils.parseProxyUrl, urlUtils.formatUrl),
 
                 set: (style, value) => {
@@ -493,7 +494,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             cursor: {
-                condition: style => typeUtils.isStyle(style),
+                condition: style => isStyle(style),
                 get:       style => cleanUpStyle(style.cursor, urlUtils.parseProxyUrl, urlUtils.formatUrl),
 
                 set: (style, value) => {
@@ -505,7 +506,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             listStyle: {
-                condition: style => typeUtils.isStyle(style),
+                condition: style => isStyle(style),
                 get:       style => cleanUpStyle(style.listStyle, urlUtils.parseProxyUrl, urlUtils.formatUrl),
 
                 set: (style, value) => {
@@ -517,7 +518,7 @@ export default class PropertyAccessorsInstrumentation extends SandboxBase {
             },
 
             listStyleImage: {
-                condition: style => typeUtils.isStyle(style),
+                condition: style => isStyle(style),
                 get:       style => cleanUpStyle(style.listStyleImage, urlUtils.parseProxyUrl, urlUtils.formatUrl),
 
                 set: (style, value) => {

--- a/src/client/sandbox/event/listeners.js
+++ b/src/client/sandbox/event/listeners.js
@@ -2,7 +2,7 @@ import nativeMethods from '../native-methods';
 import EventEmitter from '../../utils/event-emitter';
 import * as listeningCtx from './listening-context';
 import { preventDefault, stopPropagation, DOM_EVENTS } from '../../utils/event';
-import { isWindow } from '../../utils/types';
+import { isWindow } from '../../utils/dom';
 
 const LISTENED_EVENTS = [
     'click', 'mousedown', 'mouseup', 'dblclick', 'contextmenu', 'mousemove', 'mouseover', 'mouseout',

--- a/src/client/sandbox/shadow-ui.js
+++ b/src/client/sandbox/shadow-ui.js
@@ -2,7 +2,6 @@ import SandboxBase from './base';
 import nativeMethods from './native-methods';
 import * as domUtils from '../utils/dom';
 import { isWebKit } from '../utils/browser';
-import { isWindow } from '../utils/types';
 import { EVENTS } from '../dom-processor/dom-processor';
 import { getOffsetPosition } from '../utils/position';
 import { SHADOW_UI_CLASSNAME_POSTFIX, SHADOW_UI_STYLESHEET_CLASSNAME } from '../../const';
@@ -336,7 +335,7 @@ export default class ShadowUI extends SandboxBase {
         var parent = null;
 
         try {
-            if (collection.length && !isWindow(collection) && collection[0] && collection[0].nodeType) {
+            if (collection.length && !domUtils.isWindow(collection) && collection[0] && collection[0].nodeType) {
                 parent = collection[0].parentNode || collection[0].parentElement;
 
                 if (parent && (parent.childNodes === collection || parent.children === collection))

--- a/src/client/utils/position.js
+++ b/src/client/utils/position.js
@@ -207,7 +207,7 @@ export function getElementRectangle (el) {
         rectangle = getSelectChildRectangle(el);
     else {
         var elementOffset     = getOffsetPosition(el);
-        var relativeRectangle = domUtils.isSvgElement(el) ? getSvgElementRelativeRectangle(el) : el.getBoundingClientRect();
+        var relativeRectangle = domUtils.isSVGElementOrChild(el) ? getSvgElementRelativeRectangle(el) : el.getBoundingClientRect();
 
         rectangle = {
             height: relativeRectangle.height,
@@ -251,7 +251,7 @@ export function getOffsetPosition (el) {
     };
 
     if (!isInIFrame || !currentIFrame) {
-        var isSvg = domUtils.isSvgElement(el);
+        var isSvg = domUtils.isSVGElementOrChild(el);
 
         relativeRectangle = isSvg ? getSvgElementRelativeRectangle(el) : null;
 
@@ -270,7 +270,7 @@ export function getOffsetPosition (el) {
     var iframePadding  = styleUtils.getElementPadding(currentIFrame);
     var clientPosition = null;
 
-    if (domUtils.isSvgElement(el)) {
+    if (domUtils.isSVGElementOrChild(el)) {
         relativeRectangle = getSvgElementRelativeRectangle(el);
 
         clientPosition = {

--- a/src/client/utils/style.js
+++ b/src/client/utils/style.js
@@ -1,6 +1,6 @@
 import * as domUtils from './dom';
 import { isIE, isMozilla } from './browser';
-import { isWindow, isDocument } from './types';
+import { styleClass } from '../sandbox/native-methods';
 
 //NOTE: for Chrome
 const MIN_SELECT_SIZE_VALUE = 4;
@@ -11,6 +11,20 @@ function getIntValue (value) {
     var parsedValue = parseInt(value.replace('px', ''), 10);
 
     return isNaN(parsedValue) ? 0 : parsedValue;
+}
+
+export function isStyle (instance) {
+    if (instance instanceof styleClass)
+        return true;
+
+    if (instance && typeof instance === 'object' && typeof instance.border !== 'undefined') {
+        instance = instance.toString();
+
+        return instance === '[object CSSStyleDeclaration]' || instance === '[object CSS2Properties]' ||
+               instance === '[object MSStyleCSSProperties]';
+    }
+
+    return false;
 }
 
 export function get (el, property) {
@@ -112,10 +126,10 @@ export function getInnerWidth (el) {
     if (!el)
         return null;
 
-    if (isWindow(el))
+    if (domUtils.isWindow(el))
         return el.document.documentElement.clientWidth;
 
-    if (isDocument(el))
+    if (domUtils.isDocument(el))
         return el.documentElement.clientWidth;
 
     var value = el.offsetWidth;
@@ -165,10 +179,10 @@ export function getScrollLeft (el) {
     if (!el)
         return null;
 
-    if (isWindow(el))
+    if (domUtils.isWindow(el))
         return el.pageXOffset;
 
-    if (isDocument(el))
+    if (domUtils.isDocument(el))
         return el.defaultView.pageXOffset;
 
     return el.scrollLeft;
@@ -178,10 +192,10 @@ export function getScrollTop (el) {
     if (!el)
         return null;
 
-    if (isWindow(el))
+    if (domUtils.isWindow(el))
         return el.pageYOffset;
 
-    if (isDocument(el))
+    if (domUtils.isDocument(el))
         return el.defaultView.pageYOffset;
 
     return el.scrollTop;
@@ -191,7 +205,7 @@ export function setScrollLeft (el, value) {
     if (!el)
         return;
 
-    if (isWindow(el) || isDocument(el)) {
+    if (domUtils.isWindow(el) || domUtils.isDocument(el)) {
         var win       = domUtils.findDocument(el).defaultView;
         var scrollTop = getScrollTop(el);
 
@@ -205,7 +219,7 @@ export function setScrollTop (el, value) {
     if (!el)
         return;
 
-    if (isWindow(el) || isDocument(el)) {
+    if (domUtils.isWindow(el) || domUtils.isDocument(el)) {
         var win       = domUtils.findDocument(el).defaultView;
         var scrollLeft = getScrollLeft(el);
 
@@ -228,7 +242,7 @@ export function getOffsetParent (el) {
 }
 
 export function getOffset (el) {
-    if (!el || isWindow(el) || isDocument(el))
+    if (!el || domUtils.isWindow(el) || domUtils.isDocument(el))
         return null;
 
     var clientRect = el.getBoundingClientRect();

--- a/src/client/utils/types.js
+++ b/src/client/utils/types.js
@@ -1,60 +1,7 @@
-import nativeMethods from '../sandbox/native-methods';
-import { isMozilla } from './browser';
-
 export function inaccessibleTypeToStr (obj) {
     return obj === null ? 'null' : 'undefined';
-}
-
-export function isDocument (instance) {
-    if (instance instanceof nativeMethods.documentClass)
-        return true;
-
-    return instance && typeof instance === 'object' && typeof instance.referrer !== 'undefined' &&
-           instance.toString &&
-           (instance.toString() === '[object HTMLDocument]' || instance.toString() === '[object Document]');
-}
-
-export function isLocation (instance) {
-    if (instance instanceof nativeMethods.locationClass)
-        return true;
-
-    return instance && typeof instance === 'object' && typeof instance.href !== 'undefined' &&
-           typeof instance.assign !== 'undefined';
 }
 
 export function isNullOrUndefined (obj) {
     return !obj && (obj === null || typeof obj === 'undefined');
 }
-
-export function isSVGElement (obj) {
-    return window.SVGElement && obj instanceof window.SVGElement;
-}
-
-export function isStyle (instance) {
-    if (instance instanceof nativeMethods.styleClass)
-        return true;
-
-    if (instance && typeof instance === 'object' && typeof instance.border !== 'undefined') {
-        instance = instance.toString();
-
-        return instance === '[object CSSStyleDeclaration]' || instance === '[object CSS2Properties]' ||
-               instance === '[object MSStyleCSSProperties]';
-    }
-
-    return false;
-}
-
-export function isWindow (instance) {
-    if (instance instanceof nativeMethods.windowClass)
-        return true;
-
-    var result = instance && typeof instance === 'object' && typeof instance.top !== 'undefined' &&
-                 (isMozilla ? true : instance.toString && (instance.toString() === '[object Window]' ||
-                                                           instance.toString() === '[object global]'));
-
-    if (result && instance.top !== instance)
-        return isWindow(instance.top);
-
-    return result;
-}
-

--- a/src/const.js
+++ b/src/const.js
@@ -15,6 +15,7 @@ CONST.IS_STYLESHEET_PROCESSED_COMMENT = '/* stylesheet processed via hammerhead 
 CONST.UPLOAD_SANDBOX_HIDDEN_INPUT_NAME = 'hammerhead|upload-info-hidden-input';
 
 CONST.HOVER_PSEUDO_CLASS_ATTR = 'data-hammerhead-hovered';
+CONST.FOCUS_PSEUDO_CLASS_ATTR = 'data-hammerhead-focused';
 
 CONST.DOCUMENT_CHARSET = 'hammerhead|document-charset';
 

--- a/src/processing/js/instructions.js
+++ b/src/processing/js/instructions.js
@@ -4,9 +4,11 @@
 // -------------------------------------------------------------
 
 export const wrappedMethods = {
-    postMessage: true,
-    write:       true,
-    writeln:     true
+    querySelector:    true,
+    querySelectorAll: true,
+    postMessage:      true,
+    write:            true,
+    writeln:          true
 };
 
 export const wrappedProperties = {

--- a/test/client/fixtures/sandbox/event/focus-blur-change-test.js
+++ b/test/client/fixtures/sandbox/event/focus-blur-change-test.js
@@ -961,3 +961,25 @@ asyncTest('check that scrolling does not happen when focus is set (after mouse e
         start();
     }, false, true);
 });
+
+module('regression');
+
+test('querySelector must return active element even when browser is not focused (T285078)', function () {
+    input1.focus();
+
+    var result = eval(processScript('document.querySelectorAll(":focus")'));
+
+    strictEqual(result.length, 1);
+    strictEqual(result[0], input1);
+
+    input1.blur();
+
+    result = eval(processScript('document.querySelectorAll(":focus")'));
+
+    if (Browser.isIE && !Browser.isMSEdge) {
+        strictEqual(result.length, 1);
+        strictEqual(result[0], document.body);
+    }
+    else
+        strictEqual(result.length, 0);
+});

--- a/test/client/fixtures/util/dom-test.js
+++ b/test/client/fixtures/util/dom-test.js
@@ -1,5 +1,4 @@
 var DOM           = Hammerhead.get('./utils/dom');
-var Types         = Hammerhead.get('./utils/types');
 var Const         = Hammerhead.get('../const');
 var UrlUtil       = Hammerhead.get('./utils/url');
 
@@ -106,8 +105,8 @@ asyncTest('getTopSameDomainWindow', function () {
 });
 
 test('isWindow', function () {
-    ok(Types.isWindow(window));
-    ok(!Types.isWindow({ top: '' }));
+    ok(DOM.isWindow(window));
+    ok(!DOM.isWindow({ top: '' }));
 
     var storedToString = window.toString;
 
@@ -115,7 +114,7 @@ test('isWindow', function () {
         throw 'eid library overrides window.toString() method';
     };
 
-    ok(Types.isWindow(window));
+    ok(DOM.isWindow(window));
 
     window.toString = storedToString;
 });


### PR DESCRIPTION
\cc @inikulin @churkin 
When Chrome and Firefox are not focused, `querySelector`/`querySelectorAll` return `null` / `[]` instead of current active element. In context of bug `T285078`.