### PR TITLE
Build and linting configuration improvement

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "compact": false,
   "whitelist": [
     "es6.arrowFunctions",
     "es6.classes",

--- a/src/client/.babelrc
+++ b/src/client/.babelrc
@@ -1,0 +1,8 @@
+{
+  "blacklist": [
+    "es6.forOf",
+    "es7.asyncFunctions",
+    "regenerator",
+    "runtime"
+  ]
+}

--- a/src/client/.eslintrc
+++ b/src/client/.eslintrc
@@ -4,6 +4,7 @@
     "initHammerheadClient": true
   },
   "env": {
-    "browser": true
+    "browser": true,
+    "node": false
   }
 }


### PR DESCRIPTION
- don't let Babel minify big files
- disable features which requires runtime for client
- fix inherited env settings for the eslint