### PR TITLE
Hammerhead should remove service data from local storage on the first session page load (close #100)

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -95,6 +95,10 @@ class Hammerhead {
         }
     }
 
+    static _cleanLocalStorageServiceData (sessionId, window) {
+        window.localStorage.removeItem(sessionId);
+    }
+
     on (evtName, handler) {
         var eventOwner = this._getEventOwner(evtName);
 
@@ -110,10 +114,16 @@ class Hammerhead {
     }
 
     start (initSettings, win) {
-        if (initSettings)
+        win = win || window;
+
+        if (initSettings) {
             settings.set(initSettings);
 
-        this.sandbox.attach(win || window);
+            if (initSettings.isFirstPageLoad)
+                Hammerhead._cleanLocalStorageServiceData(initSettings.sessionId, win);
+        }
+
+        this.sandbox.attach(win);
     }
 }
 

--- a/src/client/task.js.mustache
+++ b/src/client/task.js.mustache
@@ -2,6 +2,7 @@ window.Hammerhead.start({
     cookie                   : '{{{cookie}}}',
     sessionId                : '{{{sessionId}}}',
     serviceMsgUrl            : '{{{serviceMsgUrl}}}',
+    isFirstPageLoad          : {{{isFirstPageLoad}}},
     ie9FileReaderShimUrl     : '{{{ie9FileReaderShimUrl}}}',
     crossDomainProxyPort     : '{{{crossDomainPort}}}',
     referer                  : '{{{referer}}}'

--- a/src/session.js
+++ b/src/session.js
@@ -17,10 +17,11 @@ export default class Session extends EventEmitter {
 
         this.uploadStorage = new UploadStorage(uploadStoragePath);
 
-        this.id         = Session._generateSessionId();
-        this.cookies    = new Cookies();
-        this.proxy      = null;
-        this.injectable = {
+        this.id            = Session._generateSessionId();
+        this.cookies       = new Cookies();
+        this.proxy         = null;
+        this.pageLoadCount = 0;
+        this.injectable    = {
             scripts: ['/hammerhead.js'],
             styles:  []
         };
@@ -46,15 +47,20 @@ export default class Session extends EventEmitter {
         if (withPayload)
             payloadScript = isIFrame ? this._getIFramePayloadScript() : this._getPayloadScript();
 
-        return mustache.render(TASK_TEMPLATE, {
+        var taskScript = mustache.render(TASK_TEMPLATE, {
             cookie:               cookies.replace(/'/g, "\\'"),
             sessionId:            this.id,
+            isFirstPageLoad:      this.pageLoadCount === 0,
             serviceMsgUrl:        serverInfo.domain + '/messaging',
             ie9FileReaderShimUrl: serverInfo.domain + '/ie9-file-reader-shim',
             crossDomainPort:      serverInfo.crossDomainPort,
             payloadScript:        payloadScript,
             referer:              referer
         });
+
+        this.pageLoadCount++;
+
+        return taskScript;
     }
 
     _getIFramePayloadScript () {

--- a/test/client/fixtures/transport-test.js
+++ b/test/client/fixtures/transport-test.js
@@ -81,6 +81,7 @@ asyncTest('queuedAsyncServiceMsg', function () {
             var expectedCompleteMsgReqs = [10, 500, 200, 300, 200];
 
             deepEqual(completeMsgReqs, expectedCompleteMsgReqs);
+
             Transport.asyncServiceMsg = savedAsyncServiceMsgFunc;
 
             start();
@@ -245,4 +246,22 @@ else {
         }, 200);
     });
 }
+
+module('regression');
+
+test('Hammerhead should remove service data from local storage on the first session page load (GH-100)', function () {
+    var sessionId = Settings.get().sessionId;
+
+    // First page loading
+    Settings.get().isFirstPageLoad = true;
+
+    // Add service data
+    window.localStorage.setItem(sessionId, 'some-serive-data');
+
+    var hammerhead = new Hammerhead.constructor(window);
+
+    hammerhead.start(Settings.get(), window);
+
+    ok(!window.localStorage.getItem(sessionId));
+});
 


### PR DESCRIPTION
\cc @AlexanderMoskovkin @inikulin @LavrovArtem 