### PR TITLE
The URL attribute is set to an empty string on the client for the second time (T295078) (fix #159)

### DIFF
--- a/src/processing/dom/index.js
+++ b/src/processing/dom/index.js
@@ -397,7 +397,7 @@ export default class DomProcessor {
         if (urlReplacer && pattern.urlAttr) {
             var storedUrlAttr     = this.getStoredAttrName(pattern.urlAttr);
             var resourceUrl       = this.adapter.getAttr(el, pattern.urlAttr);
-            var processedOnServer = !!this.adapter.getAttr(el, storedUrlAttr);
+            var processedOnServer = this.adapter.hasAttr(el, storedUrlAttr);
 
             // NOTE: page resource URL with proxy URL
             if ((resourceUrl || resourceUrl === '') && !processedOnServer) {

--- a/test/client/fixtures/sandbox/node/dom-processor-test.js
+++ b/test/client/fixtures/sandbox/node/dom-processor-test.js
@@ -342,3 +342,17 @@ test('iframe with javascript protocol in \'src\' attribute value must be process
                          Html.processHtml('<html><body><a id=\'test\' data-attr="123">link</a></body></html>') + '\'');
     strictEqual(storedSrcAttr, src);
 });
+
+test('The URL attribute must be set to an empty string on the server only once (T295078) (GH-159)', function () {
+    var iframe = NativeMethods.createElement.call(document, 'iframe');
+
+    NativeMethods.setAttribute.call(iframe, 'src', '/should_not_be_changed');
+    // NOTE: Simulating that iframe was processed on the server
+    NativeMethods.setAttribute.call(iframe, DomProcessor.getStoredAttrName('src'), '');
+
+    DomProcessor.processElement(iframe, function () {
+        return 'fail';
+    });
+
+    strictEqual(NativeMethods.getAttribute.call(iframe, 'src'), '/should_not_be_changed');
+});


### PR DESCRIPTION
@inikulin @churkin