### PR TITLE
add Chrome and Firefox MacOS browsers to the SauceLabs browse matrix (close #158)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -77,6 +77,14 @@ var CLIENT_TESTS_BROWSERS = [
         platform:    'Linux',
         version:     '5.1',
         deviceName:  'Android Emulator'
+    },
+    {
+        browserName: 'chrome',
+        platform:    'OS X 10.11'
+    },
+    {
+        browserName: 'firefox',
+        platform:    'OS X 10.11'
     }
 ];
 


### PR DESCRIPTION
/cc @inikulin @churkin 